### PR TITLE
Remove the attribute `version` from Docker Compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     #
     # Required to run project


### PR DESCRIPTION
"It is obsolete, it will be ignored, please remove it to avoid potential confusion"